### PR TITLE
Fix macOS compilation issue

### DIFF
--- a/src/rtl_test.c
+++ b/src/rtl_test.c
@@ -162,8 +162,8 @@ static int ppm_gettime(struct time_generic *tg)
 	struct timeval tv;
 
 	rv = gettimeofday(&tv, NULL);
-	ts->tv_sec = tv.tv_sec;
-	ts->tv_nsec = tv.tv_usec * 1000;
+	ts.tv_sec = tv.tv_sec;
+	ts.tv_nsec = tv.tv_usec * 1000;
 #endif
 	return rv;
 }


### PR DESCRIPTION
Small change to get the test to build in macOS 10.13.4 with Apple LLVM version 9.1.0.